### PR TITLE
Add skip options to autogrzybke call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "stderrlog",
  "tempfile",
@@ -987,6 +988,18 @@ checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ rand = "0.9.0-beta.1"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_yaml = "0.9.34+deprecated"
 chrono = { version = "0.4.39", features = ["serde"] }
+serde_urlencoded = "0.7.1"

--- a/src/autogrzybke.rs
+++ b/src/autogrzybke.rs
@@ -1,3 +1,4 @@
+use log::info;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde::{Deserialize, Deserializer};
@@ -41,6 +42,7 @@ impl AutogrzybkeImpl {
     }
 
     fn generate_playlist(&mut self, req: AutogrzybkeRequest) -> Vec<String> {
+        info!("AUTOGRZYBKE REQUEST: {req:?}");
         if req.missing.is_empty() {
             self.generate_ready_playlist()
         } else {
@@ -144,7 +146,7 @@ impl Autogrzybke {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct AutogrzybkeRequest {
     #[serde(deserialize_with = "deserialize_whitespace_separated")]
     pub missing: Vec<String>,


### PR DESCRIPTION
Couple of options to change call dynamics. Use e.g. skip_prefix to suppress adding prefixes to played list of words.